### PR TITLE
Bot now uses systemd config file to read env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "no_dup_bot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "no_dup_bot"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sheng Yang <yangsheng6810@gmail.com>"]
 edition = "2018"
 

--- a/README.org
+++ b/README.org
@@ -40,14 +40,6 @@ me - Show the number of duplicate messages I sent
 resettop - [admin only] Reset the top record for the current chat
 #+END_EXAMPLE
 
-
-** Get the code
-
-#+BEGIN_SRC sh
-git clone https://github.com/yangsheng6810/no_dup_bot.git
-cd no_dup_bot # Assume this folder is in <YOUR_PATH>.
-#+END_SRC
-
 ** Install Rust and dependencies
 
 #+BEGIN_SRC sh
@@ -57,35 +49,44 @@ sudo apt install build-essential pkg-config libssl-dev
 #+END_SRC
 
 
-** Modify & build the bot
-
-First, you need to modify =no_dup_bot= in [[https://github.com/yangsheng6810/no_dup_bot/blob/master/src/main.rs#L26][L26]] of =main.rs= to your own bot username (i.e., the one that ends with =bot=). 
-
-#+BEGIN_SRC Rust
-static BOT_NAME: &str = "no_dup_bot";
-#+END_SRC
-
-Then you can start to build the bot.
+** Get the code and build the bot
 
 #+BEGIN_SRC sh
+git clone https://github.com/yangsheng6810/no_dup_bot.git
+cd no_dup_bot # Assume this folder is in <YOUR_PATH>.
+
 cargo check # Check the bot package and all of its dependencies for errors.
 cargo build --release
-cd <YOUR_PATH>/no_dup_bot/target/release
+cd ./target/release
 #+END_SRC
 
-** Setup environment variables and start the bot
+** Setup the bot service
 
-Get =<YOUR_BOT_TOKEN>= from [[https://t.me/BotFather][@BotFather]], and get =<ADMIN_USER_ID>= from [[https://t.me/userinfobot][@userinfobot]].
+Make a copy of =nodupbot.service.example= and name it as =nodupbot.service=.
 
 #+BEGIN_SRC sh
-export TELOXIDE_TOKEN=<YOUR_BOT_TOKEN>
-export NO_DUP_BOT_ADMIN=<ADMIN_USER_ID>
+cp nodupbot.service.example nodupbot.service
 #+END_SRC
 
-Finally, start the bot and enjoy it!
+We need to modify the Line 10 - Line 15 of =nodupbot.service=. Get =<YOUR_BOT_TOKEN>= from [[https://t.me/BotFather][@BotFather]], and get =<ADMIN_USER_ID>= from [[https://t.me/userinfobot][@userinfobot]]. =YOUR_BOT_USERNAME= is the one you set in =BotFather= and ends with =bot=.
+
+#+BEGIN_EXAMPLE 
+Environment="TELOXIDE_TOKEN=<YOUR_BOT_TOKEN>"
+Environment="NO_DUP_BOT_ADMIN=<ADMIN_USER_ID>"
+Environment="NO_DUP_BOT_NAME=<YOUR_BOT_USERNAME>"
+Environment="NO_DUP_BOT_TIME_OUT_DAYS=10"
+ExecStart=<YOUR_PATH>/no_dup_bot/target/release/no_dup_bot
+WorkingDirectory=<YOUR_PATH>/no_dup_bot/target/release
+#+END_EXAMPLE
+
+
+Finally, enable and start the bot. Enjoy it!
 
 #+BEGIN_SRC sh
-cd <YOUR PATH>/no_dup_bot/target/release && ./no_dup_bot
+sudo mv nodupbot.service /etc/systemd/system
+sudo systemctl enable nodupbot # now your bot will start with the system
+sudo systemctl start nodupbot
+sudo systemctl status nodupbot # check your bot status
 #+END_SRC
 
 
@@ -108,11 +109,11 @@ You will see the following reply:
 #+BEGIN_EXAMPLE 
 These commands are supported:
 /help - Get help
-/delete - Reply to a bot message to delete it
+/delete - [admin only] Reply to a bot message to delete it
 /top - Show users with most duplicated messages
 /topics - Show most duplicated messages
 /me - Show the number of duplicate messages I sent
-/resettop - Reset the top record for the current chat
+/resettop - [admin only] Reset the top record for the current chat
 #+END_EXAMPLE
 
 When you send a command to the bot by replying to a bot's message, you only need to send =/<COMMAND>=. 

--- a/README_cn.org
+++ b/README_cn.org
@@ -39,13 +39,6 @@ resettop - [admin only] Reset the top record for the current chat
 #+END_EXAMPLE
 
 
-** 获取代码
-
-#+BEGIN_SRC sh
-git clone https://github.com/yangsheng6810/no_dup_bot.git
-cd no_dup_bot # 假设这个文件夹在 <YOUR_PATH> 中
-#+END_SRC
-
 ** 安装 Rust 与依赖
 
 #+BEGIN_SRC sh
@@ -54,35 +47,44 @@ sudo apt-get update
 sudo apt install build-essential pkg-config libssl-dev
 #+END_SRC
 
-** 修改与编译 bot
 
-你需要修改 =main.rs= [[https://github.com/yangsheng6810/no_dup_bot/blob/master/src/main.rs#L26][第26行]] 的 =no_dup_bot= 为你自己 bot 的 username （以 =bot= 结尾的那个）。 
-
-#+BEGIN_SRC Rust
-static BOT_NAME: &str = "no_dup_bot";
-#+END_SRC
-
-使用你自己喜欢的编辑器修改完成后，开始编译 bot。
+** 获取代码并编译 bot
 
 #+BEGIN_SRC sh
-cargo check # 检查 bot 与其依赖
+git clone https://github.com/yangsheng6810/no_dup_bot.git
+cd no_dup_bot # 假设这个文件夹在 <YOUR_PATH> 中
+
+cargo check # 检查 bot 代码与其依赖
 cargo build --release
 cd <YOUR_PATH>/no_dup_bot/target/release
 #+END_SRC
 
 ** 设置环境变量并启动 bot
 
-你可以在 [[https://t.me/BotFather][@BotFather]] 处获得 =<YOUR_BOT_TOKEN>= ，并在 [[https://t.me/userinfobot][@userinfobot]] 处获得 =<ADMIN_USER_ID>= 。
+复制 =nodupbot.service.example= 并重命名为 =nodupbot.service=。
 
 #+BEGIN_SRC sh
-export TELOXIDE_TOKEN=<YOUR_BOT_TOKEN>
-export NO_DUP_BOT_ADMIN=<ADMIN_USER_ID>
+cp nodupbot.service.example nodupbot.service
 #+END_SRC
+
+修改 =nodupbot.service= 的第 10 至第 15 行。你可以在 [[https://t.me/BotFather][@BotFather]] 处获得 =<YOUR_BOT_TOKEN>= ，并在 [[https://t.me/userinfobot][@userinfobot]] 处获得 =<ADMIN_USER_ID>= 。=YOUR_BOT_USERNAME= 是你在 =BotFather= 处设置，以 =bot= 结尾的 bot 用户名。
+
+#+BEGIN_EXAMPLE 
+Environment="TELOXIDE_TOKEN=<YOUR_BOT_TOKEN>"
+Environment="NO_DUP_BOT_ADMIN=<ADMIN_USER_ID>"
+Environment="NO_DUP_BOT_NAME=<YOUR_BOT_USERNAME>"
+Environment="NO_DUP_BOT_TIME_OUT_DAYS=10"
+ExecStart=<YOUR_PATH>/no_dup_bot/target/release/no_dup_bot
+WorkingDirectory=<YOUR_PATH>/no_dup_bot/target/release
+#+END_EXAMPLE
 
 最后，启动 bot 并立即开始火星救援吧！
 
 #+BEGIN_SRC sh
-cd <YOUR PATH>/no_dup_bot/target/release && ./no_dup_bot
+sudo mv nodupbot.service /etc/systemd/system
+sudo systemctl enable nodupbot # bot 将会随系统启动
+sudo systemctl start nodupbot
+sudo systemctl status nodupbot # 确认 bot 状态
 #+END_SRC
 
 
@@ -105,11 +107,11 @@ cd <YOUR PATH>/no_dup_bot/target/release && ./no_dup_bot
 #+BEGIN_EXAMPLE 
 These commands are supported:
 /help - Get help
-/delete - Reply to a bot message to delete it
+/delete - [admin only] Reply to a bot message to delete it
 /top - Show users with most duplicated messages
 /topics - Show most duplicated messages
 /me - Show the number of duplicate messages I sent
-/resettop - Reset the top record for the current chat
+/resettop - [admin only] Reset the top record for the current chat
 #+END_EXAMPLE
 
 当通过回复 bot 的消息来向 bot 发送命令时，无需在 =/<COMMAND>= 之后加上 =@<YOUR_BOT_USERNAME>= 。

--- a/nodupbot.service.example
+++ b/nodupbot.service.example
@@ -1,0 +1,24 @@
+[Unit]
+Description=no_dup_bot
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+Environment="TELOXIDE_TOKEN=<YOUR_BOT_TOKEN>"
+Environment="NO_DUP_BOT_ADMIN=<ADMIN_USER_ID>"
+Environment="NO_DUP_BOT_NAME=no_dup_bot"
+Environment="NO_DUP_BOT_TIME_OUT_DAYS=10"
+ExecStart=<YOUR_PATH>/no_dup_bot/target/release/no_dup_bot
+WorkingDirectory=<YOUR_PATH>/no_dup_bot/target/release
+TimeoutStopSec=5s
+PrivateTmp=true
+ProtectSystem=full
+Restart=always
+RestartSec=5
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Provide a systemd config file template. Environmental vars like TELOXIDE_TOKEN, NO_DUP_BOT_ADMIN, NO_DUP_BOT_NAME and NO_DUP_BOT_TIME_OUT_DAYS can be set inside.